### PR TITLE
Fix leaf loading issue

### DIFF
--- a/init.el
+++ b/init.el
@@ -1,7 +1,7 @@
 ;;; init.el --- "GNU Emacs" main config file -*- mode: Emacs-Lisp; coding: utf-8-unix; lexical-binding: t; -*-
 
 ;; Copyright (C) 2013-2019 Taku Watabe
-;; Time-stamp: <2019-09-30T16:54:33+09:00>
+;; Time-stamp: <2019-09-30T16:58:38+09:00>
 
 ;; Author: Taku Watabe <taku.eof@gmail.com>
 
@@ -569,8 +569,9 @@
 (eval-after-load 'package
   '(progn
      ;; `package' が必ず使える状況を前提とする
-     (if (not (package-installed-p 'leaf))
-         (package-install 'leaf))
+     (unless (package-installed-p 'leaf)
+       (package-refresh-contents)
+       (package-install 'leaf))
 
      (require 'leaf nil :noerror)
 

--- a/init.el
+++ b/init.el
@@ -1,7 +1,7 @@
 ;;; init.el --- "GNU Emacs" main config file -*- mode: Emacs-Lisp; coding: utf-8-unix; lexical-binding: t; -*-
 
 ;; Copyright (C) 2013-2019 Taku Watabe
-;; Time-stamp: <2019-09-30T16:58:38+09:00>
+;; Time-stamp: <2019-09-30T16:59:41+09:00>
 
 ;; Author: Taku Watabe <taku.eof@gmail.com>
 
@@ -572,8 +572,6 @@
      (unless (package-installed-p 'leaf)
        (package-refresh-contents)
        (package-install 'leaf))
-
-     (require 'leaf nil :noerror)
 
      ;; -----------------------------------------------------------------------
      ;; `leaf' キーワード群

--- a/init.el
+++ b/init.el
@@ -1,7 +1,7 @@
 ;;; init.el --- "GNU Emacs" main config file -*- mode: Emacs-Lisp; coding: utf-8-unix; lexical-binding: t; -*-
 
 ;; Copyright (C) 2013-2019 Taku Watabe
-;; Time-stamp: <2019-09-28T15:21:55+09:00>
+;; Time-stamp: <2019-09-30T16:54:33+09:00>
 
 ;; Author: Taku Watabe <taku.eof@gmail.com>
 
@@ -572,7 +572,17 @@
      (if (not (package-installed-p 'leaf))
          (package-install 'leaf))
 
-     (require 'leaf nil :noerror)))
+     (require 'leaf nil :noerror)
+
+     ;; -----------------------------------------------------------------------
+     ;; `leaf' キーワード群
+     ;; -----------------------------------------------------------------------
+     (leaf leaf-keywords
+       ;; :disabled t ;; FIXME: "Error msg: Symbol’s value as variable is void: leaf--value" が出ている問題を回避したい
+       :package t
+       :config
+       (if (fboundp 'leaf-keywords-init)
+           (leaf-keywords-init)))))
 
 
 ;; ============================================================================
@@ -589,17 +599,6 @@
      ;; =======================================================================
      (leaf *packages
        :config
-       ;; ---------------------------------------------------------------------
-       ;; `leaf' キーワード群
-       ;; ---------------------------------------------------------------------
-       (leaf leaf-keywords
-         :disabled t ;; FIXME: "Error msg: Symbol’s value as variable is void: leaf--value" が出ている問題を回避したい
-         :package t
-         :config
-         (if (fboundp 'leaf-keywords-init)
-             (leaf-keywords-init)))
-
-
        ;; ---------------------------------------------------------------------
        ;; EWW (Emacs Web Wowser, Web Browser)
        ;; ---------------------------------------------------------------------


### PR DESCRIPTION
教えて頂いたエラーを解消できるように少し修正しました。
少し試してもらえれば幸いです。

なお、このレポジトリを一時的に.emacs.dとして読み込んだのですが、別途
```
Warning (leaf): In `point-undo' block, failed to :package of point-undo.  Error msg: Package ‘point-undo-’ is unavailable
Warning (leaf): In `bookmark+' block, failed to :package of bookmark+.  Error msg: Package ‘bookmark+-’ is unavailable
Warning (leaf): Error in `bookmark+' block.  Error msg: Cannot open load file: No such file or directory, bookmark+
Warning (leaf): In `dired+' block, failed to :package of dired+.  Error msg: Package ‘dired+-’ is unavailable
Warning (leaf): Error in `dired+' block.  Error msg: Cannot open load file: No such file or directory, dired+
Warning (emacs): Couldn’t find minor-mode-alist inside ‘mode-line-modes’. If you didn’t change it yourself, please file a bug report with M-x rm-bug-report
```
というワーニングが出たので、一応報告します。`